### PR TITLE
Fix "Unable to preventDefault" error in Chrome

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,12 @@ export default class HorizontalScroll extends EventEmitter {
 
         // bind events
         this.container = container;
-        this.container.addEventListener('wheel', this.wheel);
-        document.addEventListener('keydown', this.keydown);
+        this.container.addEventListener('wheel', this.wheel, {
+            passive: false,
+        });
+        document.addEventListener('keydown', this.keydown, {
+            passive: false,
+        });
 
         // set up interaction observer
         if (this.container !== document.documentElement) {


### PR DESCRIPTION
There was an issue in Google Chrome when using this plugin with Nuxt.js. Chrome was generating the following error when using the mousewheel:

> Unable to preventDefault inside passive event listener due to target being treated as passive.

This was due to using `preventDefault` in the callback functions. 
I fixed it by specifying `passive: false` in the arguments of `addEventListener` (see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Parameters)